### PR TITLE
chore: qol features for `frontend-v2` impl

### DIFF
--- a/site/src/app/trajectory/page.tsx
+++ b/site/src/app/trajectory/page.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import dynamic from "next/dynamic";
 import { Suspense } from "react";
+import { TrajectoryHeader } from "$/components/header";
 
 export default function TrajectoryPage() {
   const TrajectoryMap = dynamic(() => import("$/components/trajectory-map"), {
@@ -15,26 +16,30 @@ export default function TrajectoryPage() {
   });
 
   return (
-    <div className="min-h-screen">
-      <div className="container mx-auto py-8 px-4">
-        <h1 className="text-3xl font-bold mb-6">
-          Plastic Trajectory Visualization
-        </h1>
-        <p className="mb-6">
-          Visualize the movement of plastic particles in the ocean and their
-          potential paths. The animation shows how plastic flows from a starting
-          point through different environments.
-        </p>
+    <div className="min-h-screen flex flex-col">
+      <TrajectoryHeader />
 
-        <Suspense
-          fallback={
-            <div className="flex items-center justify-center h-96">
-              Loading...
-            </div>
-          }
-        >
-          <TrajectoryMap />
-        </Suspense>
+      <div className="flex-1">
+        <div className="container mx-auto py-8 px-4">
+          <h1 className="text-3xl font-bold mb-6">
+            Plastic Trajectory Visualization
+          </h1>
+          <p className="mb-6">
+            Visualize the movement of plastic particles in the ocean and their
+            potential paths. The animation shows how plastic flows from a
+            starting point through different environments.
+          </p>
+
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-96">
+                Loading...
+              </div>
+            }
+          >
+            <TrajectoryMap />
+          </Suspense>
+        </div>
       </div>
     </div>
   );

--- a/site/src/components/footer.tsx
+++ b/site/src/components/footer.tsx
@@ -10,7 +10,7 @@ import {
 
 export function FooterComponent() {
   return (
-    <footer className="bg-black text-white py-12 mt-12">
+    <footer className="bg-neutral-800 text-white py-12 mt-12">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           <div>

--- a/site/src/components/header.tsx
+++ b/site/src/components/header.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+import { IconBrandGithub } from "@tabler/icons-react";
+import Link from "next/link";
+
+export function TrajectoryHeader() {
+  return (
+    <div className="w-full bg-neutral-800 px-4 py-3">
+      <div className="container mx-auto flex justify-between items-center">
+        <div className="text-xl font-bold">
+          <span className="bg-gradient-to-r from-fuchsia-500 via-amber-500 to-pink-400 bg-clip-text text-transparent">
+            محيطك
+          </span>
+        </div>
+
+        <Link
+          href="https://github.com/qcecothing/mohituQ"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-gray-400 hover:text-white transition-colors"
+        >
+          <IconBrandGithub size={24} />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -2,11 +2,11 @@
 import React from "react";
 import { FloatingNav } from "$/components/ui/floating-navbar";
 import {
-  IconApps,
+  IconBulb,
+  IconChartBar,
+  IconEye,
   IconHome,
-  IconMessage,
-  IconSettings,
-  IconUser,
+  IconMap,
 } from "@tabler/icons-react";
 
 export function Navbar() {
@@ -19,27 +19,27 @@ export function Navbar() {
     {
       name: "Vision",
       link: "/#vision",
-      icon: <IconUser className="h-4 w-4 text-neutral-500" />,
+      icon: <IconEye className="h-4 w-4 text-neutral-500" />,
     },
     {
       name: "State",
       link: "/#state",
-      icon: <IconMessage className="h-4 w-4 text-neutral-500" />,
+      icon: <IconChartBar className="h-4 w-4 text-neutral-500" />,
     },
     {
       name: "Solution",
       link: "/#solution",
-      icon: <IconSettings className="h-4 w-4 text-neutral-500" />,
+      icon: <IconBulb className="h-4 w-4 text-neutral-500" />,
     },
     {
       name: "App",
       link: "/trajectory",
-      icon: <IconApps className="h-4 w-4 text-neutral-500" />,
+      icon: <IconMap className="h-4 w-4 text-neutral-500" />,
     },
   ];
 
   return (
-    <div className="relative  w-full">
+    <div className="relative w-full">
       <FloatingNav navItems={navItems} />
     </div>
   );

--- a/site/src/components/trajectory-map.tsx
+++ b/site/src/components/trajectory-map.tsx
@@ -38,9 +38,6 @@ export type CombinedPoint = {
   segment: TrajectorySegment;
 };
 
-// -----------------------------------------------------------------------------
-// Updated getCombinedPath - now accepts sourceLat and sourceLon so that the
-// generated route starts from the actual source's coordinates.
 const getCombinedPath = (
   trajectoryData: TrajectoryData | null,
   sourceLat: number,
@@ -307,7 +304,6 @@ const TrajectoryMap: React.FC = () => {
 
   const [selectedCity, setSelectedCity] = useState(biggestCities[0].name);
 
-  // Create a ref to hold the Leaflet map instance.
   const mapRef = useRef<L.Map | null>(null);
 
   const fetchTrajectoryForSource = async (src: Source) => {
@@ -414,7 +410,6 @@ const TrajectoryMap: React.FC = () => {
     }
   };
 
-  // Center function that centers the map on the currently followed source.
   const centerMap = () => {
     if (!mapRef.current) return;
     const source = sources.find(
@@ -502,9 +497,8 @@ const TrajectoryMap: React.FC = () => {
 
   return (
     <div className="flex flex-col h-screen w-full overflow-hidden bg-slate-50">
-      {/* Top Collapsible Panel */}
       <div
-        className="bg-white shadow-sm transition-all duration-300 overflow-hidden"
+        className="bg-white shadow-sm transition-all duration-300 overflow-y-scroll"
         style={{
           height: panelOpen ? "auto" : "0",
           maxHeight: panelOpen ? "60vh" : "0",
@@ -534,7 +528,6 @@ const TrajectoryMap: React.FC = () => {
             </button>
           </div>
 
-          {/* Existing source editors */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {sources.map((src) => (
               <div
@@ -618,7 +611,6 @@ const TrajectoryMap: React.FC = () => {
               </div>
             ))}
 
-            {/* Add new source manually */}
             <div className="bg-neutral-200 rounded-lg flex flex-col justify-center items-center p-4">
               <button
                 onClick={() => addSource()}
@@ -639,7 +631,6 @@ const TrajectoryMap: React.FC = () => {
                 Add Source Manually
               </button>
 
-              {/* Add new source from Biggest Cities */}
               <div className="flex flex-col items-center space-y-2">
                 <select
                   value={selectedCity}
@@ -675,7 +666,6 @@ const TrajectoryMap: React.FC = () => {
         </div>
       </div>
 
-      {/* Header */}
       <div className="bg-white p-3 shadow-sm border-b border-slate-200">
         <div className="flex justify-between items-center">
           <button
@@ -730,7 +720,6 @@ const TrajectoryMap: React.FC = () => {
           </select>
 
           <div className="flex items-center space-x-4">
-            {/* New Center Button */}
             <button
               onClick={centerMap}
               className="p-2 bg-blue-100 text-blue-700 rounded-md hover:bg-blue-200 focus:outline-none"
@@ -812,7 +801,6 @@ const TrajectoryMap: React.FC = () => {
         </div>
       </div>
 
-      {/* Map Area */}
       <div className="flex-1 relative">
         <div className="h-full w-full">
           <MapContainer
@@ -831,7 +819,6 @@ const TrajectoryMap: React.FC = () => {
               const shouldFollow = activeFollowSourceId === src.id;
               return (
                 <React.Fragment key={src.id}>
-                  {/* If this source's trajectory is still loading, show spinner marker */}
                   {loadingRoutes[src.id]
                     ? (
                       <Marker


### PR DESCRIPTION
This pull request introduces several updates to the `TrajectoryPage` and its related components, focusing on enhancing the user interface, improving code readability, and adding new functionality. The changes include the addition of a new `TrajectoryHeader` component, updates to the `Navbar` icons, and cleanup of commented-out code in the `TrajectoryMap` component.

### UI Enhancements:
* Added a new `TrajectoryHeader` component to the `TrajectoryPage`, which includes branding and a GitHub link. This component is styled with a gradient text logo and a GitHub icon. (`site/src/app/trajectory/page.tsx`, `site/src/components/header.tsx`) [[1]](diffhunk://#diff-868378ea67cbce343979891f8623a5f7c6adb16007969ac1f4a1713ce0b02c1bR6) [[2]](diffhunk://#diff-868378ea67cbce343979891f8623a5f7c6adb16007969ac1f4a1713ce0b02c1bL18-R30) [[3]](diffhunk://#diff-868378ea67cbce343979891f8623a5f7c6adb16007969ac1f4a1713ce0b02c1bR44) [[4]](diffhunk://#diff-54e2430767ce3cecd524d63ad03b53977e2cbec770c312ad5fd67e5d4c30acc4R1-R28)
* Updated the footer background color from black to a neutral gray (`bg-neutral-800`) for improved consistency with the overall design. (`site/src/components/footer.tsx`)

### Navbar Updates:
* Replaced several `Navbar` icons with more contextually relevant ones (e.g., `IconEye` for "Vision," `IconChartBar` for "State"). (`site/src/components/navbar.tsx`) [[1]](diffhunk://#diff-ea0fda570a74f9ac7a018c5392b796054c7f28ea23cca1dad9ed962dbbe54fefL5-R9) [[2]](diffhunk://#diff-ea0fda570a74f9ac7a018c5392b796054c7f28ea23cca1dad9ed962dbbe54fefL22-R37)

### Code Cleanup:
* Removed outdated or redundant comments from the `TrajectoryMap` component to improve code readability. These include comments for the map's center function, header, and other UI elements. (`site/src/components/trajectory-map.tsx`) [[1]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL310) [[2]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL417) [[3]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL505-R501) [[4]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL537) [[5]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL621) [[6]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL642) [[7]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL678) [[8]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL733) [[9]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL815) [[10]](diffhunk://#diff-a9e8ddfd43dc6ea370dd827fe0a324731c6fdd4f1b438bb9e4ec94e1589dc58fL834)